### PR TITLE
added sfctl cluster connect command to install/uninstall scripts

### DIFF
--- a/Linux/container-tutorial/Voting/install.sh
+++ b/Linux/container-tutorial/Voting/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
+if [ -z "$1" ]; then
+	echo "Missing http-schema cluster endpoint connection string."
+	echo "If running locally, will be http://localhost:19080."
+	exit 1
+fi
+
+sfctl cluster select --endpoint $1
 sfctl application upload --path Voting --show-progress
 sfctl application provision --application-type-build-path Voting
 sfctl application create --app-name fabric:/Voting --app-type VotingType --app-version 1.0.0
-

--- a/Linux/container-tutorial/Voting/uninstall.sh
+++ b/Linux/container-tutorial/Voting/uninstall.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ -z "$1" ]; then
+	echo "Missing http-schema cluster endpoint connection string."
+	echo "If running locally, will be http://localhost:19080."
+	exit 1
+fi
+
+sfctl cluster select --endpoint $1
 sfctl application delete --application-id Voting
 sfctl application unprovision --application-type-name VotingType --application-type-version 1.0.0
 sfctl store delete --content-path Voting


### PR DESCRIPTION
Added `sfctl` cluster connect to bash scripts to reduce `./install.sh` script from failing to deploy an application.