### PR TITLE
Use equivalent MCR image for Linux container sample

### DIFF
--- a/Linux/container-tutorial/azure-vote/Dockerfile
+++ b/Linux/container-tutorial/azure-vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM    tiangolo/uwsgi-nginx-flask:python3.6
+FROM    mcr.microsoft.com/azuredocs/uwsgi-nginx-flask:python3.6
 
 RUN     pip install redis
  


### PR DESCRIPTION
Remove DockerHub dependency by pointing to (newly ported) MCR equivalent image.

Fixes AB#1830579