### PR TITLE
Use MCR equivalent image for azure voting sample

### DIFF
--- a/Linux/container-tutorial/Voting/Voting/azurevotefrontPkg/ServiceManifest.xml
+++ b/Linux/container-tutorial/Voting/Voting/azurevotefrontPkg/ServiceManifest.xml
@@ -10,7 +10,7 @@
    <CodePackage Name="code" Version="1.0.0">
       <EntryPoint>
          <ContainerHost>
-            <ImageName>suhuruli/azure-vote-front</ImageName>
+            <ImageName>mcr.microsoft.com/azuredocs/azure-vote-front:v1</ImageName>
             <Commands></Commands>
          </ContainerHost>
       </EntryPoint>

--- a/Linux/container-tutorial/azure-vote/Dockerfile
+++ b/Linux/container-tutorial/azure-vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM    tiangolo/uwsgi-nginx-flask:3.6
+FROM    tiangolo/uwsgi-nginx-flask:python3.6
 
 RUN     pip install redis
  

--- a/Linux/container-tutorial/azure-vote/Dockerfile
+++ b/Linux/container-tutorial/azure-vote/Dockerfile
@@ -1,4 +1,4 @@
-FROM    tiangolo/uwsgi-nginx-flask:python3.6
+FROM    tiangolo/uwsgi-nginx-flask:latest
 
 RUN     pip install redis
  

--- a/Linux/container-tutorial/docker-compose.yml
+++ b/Linux/container-tutorial/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         - "6379:6379"
 
   azure-vote-front:
-    image: suhuruli/azure-vote-front
+    image: mcr.microsoft.com/azuredocs/azure-vote-front:v1
     deploy:
       replicas: 1
     ports:


### PR DESCRIPTION
Also revert back to tiangolo/uwsgi-nginx-flask:python3.6 image for now. 